### PR TITLE
chore: make userInputBtcAddr optional as docs suggest

### DIFF
--- a/packages/orderbook/src/lib/orderbook.ts
+++ b/packages/orderbook/src/lib/orderbook.ts
@@ -109,7 +109,12 @@ export class Orderbook implements IOrderbook {
     const contracts = await this.getSupportedContracts();
     const orderPair = orderPairGenerator(fromAsset, toAsset, contracts);
 
-    const url = this.url.endpoint("orders");
+    const btcInputAddress =
+      rest.sendAddress.slice(0, 2) === '0x'
+        ? rest.receiveAddress
+        : rest.sendAddress;
+
+    const url = this.url.endpoint('orders');
     const { orderId } = await Fetcher.post<CreateOrderResponse>(url, {
       body: JSON.stringify({
         ...rest,
@@ -117,7 +122,9 @@ export class Orderbook implements IOrderbook {
         receiveAmount,
         secretHash: trim0x(secretHash),
         orderPair,
-        userWalletBTCAddress: rest.btcInputAddress,
+        // should not be forced to define btcInput (as docs suggest) for wbtc/eth flow
+        // this handles undefined case by defaulting back to users btcAddr
+        userWalletBTCAddress: rest.btcInputAddress ?? btcInputAddress,
       }),
       headers: {
         Authorization: await this.auth.getToken(),

--- a/packages/orderbook/src/lib/orderbook.ts
+++ b/packages/orderbook/src/lib/orderbook.ts
@@ -122,7 +122,7 @@ export class Orderbook implements IOrderbook {
         receiveAmount,
         secretHash: trim0x(secretHash),
         orderPair,
-        // shouldn't we be forced to define btcInput? (as docs suggest) for btc/wntc flow
+        // shouldn't we not be forced to define btcInput? (as docs suggest) for btc/wntc flow
         // this handles undefined case by defaulting back to users btcAddr
         userWalletBTCAddress: rest.btcInputAddress ?? btcInputAddress,
       }),

--- a/packages/orderbook/src/lib/orderbook.ts
+++ b/packages/orderbook/src/lib/orderbook.ts
@@ -1,4 +1,4 @@
-import { Fetcher, trim0x } from '@catalogfi/utils';
+import { Fetcher, trim0x } from "@catalogfi/utils";
 import {
   CreateOrderConfig,
   CreateOrderResponse,
@@ -8,17 +8,17 @@ import {
   OrderConfig,
   OrderNonVerbose,
   OrderbookConfig,
-} from './orderbook.types';
-import { OrdersSocket } from './ordersSocket';
-import { Siwe } from './auth/siwe';
-import { IAuth } from './auth/auth.interface';
-import { orderPairGenerator } from './orderpair';
-import { OrderbookErrors } from './errors';
-import { StoreKeys } from './store/store.interface';
-import { MemoryStorage } from './store/memoryStorage';
-import { API } from './api';
-import { Url } from './url';
-import { Chain, SupportedContracts } from './asset';
+} from "./orderbook.types";
+import { OrdersSocket } from "./ordersSocket";
+import { Siwe } from "./auth/siwe";
+import { IAuth } from "./auth/auth.interface";
+import { orderPairGenerator } from "./orderpair";
+import { OrderbookErrors } from "./errors";
+import { StoreKeys } from "./store/store.interface";
+import { MemoryStorage } from "./store/memoryStorage";
+import { API } from "./api";
+import { Url } from "./url";
+import { Chain, SupportedContracts } from "./asset";
 
 /**
  * A class that allows you to create and manage orders with the backend url.
@@ -39,7 +39,7 @@ export class Orderbook implements IOrderbook {
    *
    */
   constructor(orderbookConfig: OrderbookConfig) {
-    this.url = new Url('/', orderbookConfig.url ?? API);
+    this.url = new Url("/", orderbookConfig.url ?? API);
     this.orderSocket = new OrdersSocket(this.url.socket());
 
     this.auth = new Siwe(this.url, orderbookConfig.signer, {
@@ -56,7 +56,7 @@ export class Orderbook implements IOrderbook {
 
   static async init(orderbookConfig: OrderbookConfig) {
     const auth = new Siwe(
-      new Url('/', orderbookConfig.url ?? API),
+      new Url("/", orderbookConfig.url ?? API),
       orderbookConfig.signer,
       orderbookConfig.opts
     );
@@ -76,7 +76,7 @@ export class Orderbook implements IOrderbook {
     if (Object.keys(this.supportedContracts).length > 0)
       return this.supportedContracts;
 
-    const url = this.url.endpoint('assets');
+    const url = this.url.endpoint("assets");
     const assetsFromOrderbook = await Fetcher.get<
       Partial<Record<Chain, string[]>>
     >(url);
@@ -122,7 +122,7 @@ export class Orderbook implements IOrderbook {
         receiveAmount,
         secretHash: trim0x(secretHash),
         orderPair,
-        // should not be forced to define btcInput (as docs suggest) for btc/wbtc flow
+        // shouldn't we be forced to define btcInput? (as docs suggest) for btc/wntc flow
         // this handles undefined case by defaulting back to users btcAddr
         userWalletBTCAddress: rest.btcInputAddress ?? btcInputAddress,
       }),
@@ -140,11 +140,11 @@ export class Orderbook implements IOrderbook {
   ): Promise<(T extends true ? Order : OrderNonVerbose)[]> {
     const ordersResponse = await Fetcher.get<GetOrdersOutput<T>>(
       this.url +
-        'orders?' +
+        "orders?" +
         new URLSearchParams({
           ...(orderConfig?.taker ? { taker: address } : { maker: address }),
-          verbose: orderConfig?.verbose ? 'true' : 'false',
-          ...(orderConfig?.pending ? { status: '2' } : {}),
+          verbose: orderConfig?.verbose ? "true" : "false",
+          ...(orderConfig?.pending ? { status: "2" } : {}),
         })
     );
 
@@ -167,10 +167,10 @@ export class Orderbook implements IOrderbook {
     const { sendAmount, receiveAmount } = config;
     const inputAmount = +sendAmount;
     const outputAmount = +receiveAmount;
-    if (isNaN(inputAmount) || inputAmount <= 0 || sendAmount.includes('.'))
+    if (isNaN(inputAmount) || inputAmount <= 0 || sendAmount.includes("."))
       throw new Error(OrderbookErrors.INVALID_SEND_AMOUNT);
 
-    if (isNaN(outputAmount) || outputAmount <= 0 || receiveAmount.includes('.'))
+    if (isNaN(outputAmount) || outputAmount <= 0 || receiveAmount.includes("."))
       throw new Error(OrderbookErrors.INVALID_RECEIVE_AMOUNT);
   }
 }

--- a/packages/orderbook/src/lib/orderbook.ts
+++ b/packages/orderbook/src/lib/orderbook.ts
@@ -1,4 +1,4 @@
-import { Fetcher, trim0x } from "@catalogfi/utils";
+import { Fetcher, trim0x } from '@catalogfi/utils';
 import {
   CreateOrderConfig,
   CreateOrderResponse,
@@ -8,17 +8,17 @@ import {
   OrderConfig,
   OrderNonVerbose,
   OrderbookConfig,
-} from "./orderbook.types";
-import { OrdersSocket } from "./ordersSocket";
-import { Siwe } from "./auth/siwe";
-import { IAuth } from "./auth/auth.interface";
-import { orderPairGenerator } from "./orderpair";
-import { OrderbookErrors } from "./errors";
-import { StoreKeys } from "./store/store.interface";
-import { MemoryStorage } from "./store/memoryStorage";
-import { API } from "./api";
-import { Url } from "./url";
-import { Chain, SupportedContracts } from "./asset";
+} from './orderbook.types';
+import { OrdersSocket } from './ordersSocket';
+import { Siwe } from './auth/siwe';
+import { IAuth } from './auth/auth.interface';
+import { orderPairGenerator } from './orderpair';
+import { OrderbookErrors } from './errors';
+import { StoreKeys } from './store/store.interface';
+import { MemoryStorage } from './store/memoryStorage';
+import { API } from './api';
+import { Url } from './url';
+import { Chain, SupportedContracts } from './asset';
 
 /**
  * A class that allows you to create and manage orders with the backend url.
@@ -39,7 +39,7 @@ export class Orderbook implements IOrderbook {
    *
    */
   constructor(orderbookConfig: OrderbookConfig) {
-    this.url = new Url("/", orderbookConfig.url ?? API);
+    this.url = new Url('/', orderbookConfig.url ?? API);
     this.orderSocket = new OrdersSocket(this.url.socket());
 
     this.auth = new Siwe(this.url, orderbookConfig.signer, {
@@ -56,7 +56,7 @@ export class Orderbook implements IOrderbook {
 
   static async init(orderbookConfig: OrderbookConfig) {
     const auth = new Siwe(
-      new Url("/", orderbookConfig.url ?? API),
+      new Url('/', orderbookConfig.url ?? API),
       orderbookConfig.signer,
       orderbookConfig.opts
     );
@@ -76,7 +76,7 @@ export class Orderbook implements IOrderbook {
     if (Object.keys(this.supportedContracts).length > 0)
       return this.supportedContracts;
 
-    const url = this.url.endpoint("assets");
+    const url = this.url.endpoint('assets');
     const assetsFromOrderbook = await Fetcher.get<
       Partial<Record<Chain, string[]>>
     >(url);
@@ -122,7 +122,7 @@ export class Orderbook implements IOrderbook {
         receiveAmount,
         secretHash: trim0x(secretHash),
         orderPair,
-        // should not be forced to define btcInput (as docs suggest) for wbtc/eth flow
+        // should not be forced to define btcInput (as docs suggest) for btc/wbtc flow
         // this handles undefined case by defaulting back to users btcAddr
         userWalletBTCAddress: rest.btcInputAddress ?? btcInputAddress,
       }),
@@ -140,11 +140,11 @@ export class Orderbook implements IOrderbook {
   ): Promise<(T extends true ? Order : OrderNonVerbose)[]> {
     const ordersResponse = await Fetcher.get<GetOrdersOutput<T>>(
       this.url +
-        "orders?" +
+        'orders?' +
         new URLSearchParams({
           ...(orderConfig?.taker ? { taker: address } : { maker: address }),
-          verbose: orderConfig?.verbose ? "true" : "false",
-          ...(orderConfig?.pending ? { status: "2" } : {}),
+          verbose: orderConfig?.verbose ? 'true' : 'false',
+          ...(orderConfig?.pending ? { status: '2' } : {}),
         })
     );
 
@@ -167,10 +167,10 @@ export class Orderbook implements IOrderbook {
     const { sendAmount, receiveAmount } = config;
     const inputAmount = +sendAmount;
     const outputAmount = +receiveAmount;
-    if (isNaN(inputAmount) || inputAmount <= 0 || sendAmount.includes("."))
+    if (isNaN(inputAmount) || inputAmount <= 0 || sendAmount.includes('.'))
       throw new Error(OrderbookErrors.INVALID_SEND_AMOUNT);
 
-    if (isNaN(outputAmount) || outputAmount <= 0 || receiveAmount.includes("."))
+    if (isNaN(outputAmount) || outputAmount <= 0 || receiveAmount.includes('.'))
       throw new Error(OrderbookErrors.INVALID_RECEIVE_AMOUNT);
   }
 }

--- a/packages/orderbook/src/lib/orderbook.types.ts
+++ b/packages/orderbook/src/lib/orderbook.types.ts
@@ -2,7 +2,6 @@ import { MarkNonNullable } from "@catalogfi/utils";
 import { Asset, SupportedContracts } from "./asset";
 import { JsonRpcSigner, Wallet } from "ethers";
 import { IStore } from "./store/store.interface";
-
 /**
  * Configuration for the orders you want to receive
  *
@@ -59,7 +58,7 @@ export interface CreateOrderConfig {
   /**
    * The funds are received at this address if specified, otherwise the funds are sent to the receive address.
    */
-  btcInputAddress: string;
+  btcInputAddress?: string;
 
   /**
    * Pay with seed


### PR DESCRIPTION
the docs seem to suggest btcInputAddress param in the createOrderBook config is optional. which should be the case especialy for BTC/WBTC flow. And is only desirable in WBTC/BTC flow when funds want to go to to different recipient than sender.

This is my take from using the garden library. Right now the param is required so have to pass it even in the bridge slow where btc recipient isnt nessecary. i made this PR just to fix that type to optional and to handle a possible undefined case from doing so in the actual createOrder function