### PR TITLE
fix: arbitrum localnet wbtc asset

### DIFF
--- a/packages/orderbook/package.json
+++ b/packages/orderbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gardenfi/orderbook",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "dependencies": {
     "@catalogfi/utils": "^0.1.6",

--- a/packages/orderbook/src/lib/asset.ts
+++ b/packages/orderbook/src/lib/asset.ts
@@ -62,7 +62,7 @@ export const Assets = {
       name: "Wrapped Bitcoin",
       symbol: "WBTC",
       decimals: 8,
-      chain: Chains.ethereum_arbitrum,
+      chain: Chains.ethereum_arbitrumlocalnet,
       isToken: true,
       thumbnail: "https://cryptologos.cc/logos/wrapped-bitcoin-wbtc-logo.svg",
       address: "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",


### PR DESCRIPTION
Previous wbtc arbitrum localnet asset used `ethereum_arbitrum`, changed it to `ethereum_arbitrumlocalnet`.