### PR TITLE
chore: export mainnet and testnet apis

### DIFF
--- a/packages/orderbook/package.json
+++ b/packages/orderbook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gardenfi/orderbook",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "type": "module",
   "dependencies": {
     "@catalogfi/utils": "^0.1.6",

--- a/packages/orderbook/src/index.ts
+++ b/packages/orderbook/src/index.ts
@@ -9,3 +9,4 @@ export { chainToId, idToChain, orderPairGenerator } from './lib/orderpair';
 export type { Chain, EvmChain, Asset, ChainData } from './lib/asset';
 export { Chains, Assets, ChainsData, isMainnet } from './lib/asset';
 export { parseStatus, Actions } from './lib/utils';
+export { MAINNET_ORDERBOOK_API, TESTNET_ORDERBOOK_API } from './lib/api';

--- a/packages/orderbook/src/lib/api.ts
+++ b/packages/orderbook/src/lib/api.ts
@@ -1,1 +1,3 @@
-export const API = 'https://api.garden.finance';
+export const MAINNET_ORDERBOOK_API = 'https://api.garden.finance';
+export const TESTNET_ORDERBOOK_API =
+  'https://orderbook-testnet.garden.finance/';

--- a/packages/orderbook/src/lib/api.ts
+++ b/packages/orderbook/src/lib/api.ts
@@ -1,3 +1,3 @@
 export const MAINNET_ORDERBOOK_API = 'https://api.garden.finance';
 export const TESTNET_ORDERBOOK_API =
-  'https://orderbook-testnet.garden.finance/';
+  'https://orderbook-testnet.garden.finance';

--- a/packages/orderbook/src/lib/auth/siwe.ts
+++ b/packages/orderbook/src/lib/auth/siwe.ts
@@ -1,110 +1,106 @@
-import { JsonRpcSigner, Wallet } from "ethers";
-import { IAuth } from "./auth.interface";
+import { JsonRpcSigner, Wallet } from 'ethers';
+import { IAuth } from './auth.interface';
 
-import { SiweMessage } from "siwe";
-import { Fetcher } from "@catalogfi/utils";
-import { OrderbookOpts } from "../orderbook.types";
-import { IStore, StoreKeys } from "../store/store.interface";
-import { MemoryStorage } from "../store/memoryStorage";
-import { API } from "../api";
-import { Url } from "../url";
+import { SiweMessage } from 'siwe';
+import { Fetcher } from '@catalogfi/utils';
+import { OrderbookOpts } from '../orderbook.types';
+import { IStore, StoreKeys } from '../store/store.interface';
+import { MemoryStorage } from '../store/memoryStorage';
+import { MAINNET_ORDERBOOK_API } from '../api';
+import { Url } from '../url';
 
 export class Siwe implements IAuth {
-    private readonly url: Url;
-    private store: IStore;
-    private readonly signer: JsonRpcSigner | Wallet;
-    private readonly signingStatement: string = "I'm signing in to Catalog";
-    private readonly domain: string;
-    constructor(
-        url: Url,
-        signer: JsonRpcSigner | Wallet,
-        opts?: OrderbookOpts
-    ) {
-        this.url = new Url("/", url ?? API);
-        this.signer = signer;
-        this.domain = opts?.domain || "catalog.fi";
-        if (this.domain.startsWith("https://")) {
-            this.domain = this.domain.split("https://")[1];
-        }
-        this.store = opts?.store ?? new MemoryStorage();
+  private readonly url: Url;
+  private store: IStore;
+  private readonly signer: JsonRpcSigner | Wallet;
+  private readonly signingStatement: string = "I'm signing in to Catalog";
+  private readonly domain: string;
+  constructor(url: Url, signer: JsonRpcSigner | Wallet, opts?: OrderbookOpts) {
+    this.url = new Url('/', url ?? MAINNET_ORDERBOOK_API);
+    this.signer = signer;
+    this.domain = opts?.domain || 'catalog.fi';
+    if (this.domain.startsWith('https://')) {
+      this.domain = this.domain.split('https://')[1];
     }
+    this.store = opts?.store ?? new MemoryStorage();
+  }
 
-    verifyToken(token: string, account: string) {
-        const parsedToken = parseJwt(token);
-        if (!parsedToken) return false;
+  verifyToken(token: string, account: string) {
+    const parsedToken = parseJwt(token);
+    if (!parsedToken) return false;
 
-        try {
-            const utcTimestampNow = Math.floor(Date.now() / 1000) + 120; // auth should be valid for atleast 2 minutes
-            return (
-                parsedToken.exp > utcTimestampNow &&
-                parsedToken.userWallet.toLowerCase() === account.toLowerCase()
-            );
-        } catch (error) {
-            return false;
-        }
+    try {
+      const utcTimestampNow = Math.floor(Date.now() / 1000) + 120; // auth should be valid for atleast 2 minutes
+      return (
+        parsedToken.exp > utcTimestampNow &&
+        parsedToken.userWallet.toLowerCase() === account.toLowerCase()
+      );
+    } catch (error) {
+      return false;
     }
+  }
 
-    async getToken(): Promise<string> {
-        const authToken = this.store.getItem(StoreKeys.AUTH_TOKEN);
-        if (authToken && this.verifyToken(authToken, this.signer.address))
-            return authToken;
+  async getToken(): Promise<string> {
+    const authToken = this.store.getItem(StoreKeys.AUTH_TOKEN);
+    if (authToken && this.verifyToken(authToken, this.signer.address))
+      return authToken;
 
-        const { message, signature } = await this.signStatement();
-        const { token } = await Fetcher.post<{ token: string }>(
-            this.url.endpoint("verify"),
-            {
-                body: JSON.stringify({
-                    message,
-                    signature,
-                }),
-            }
-        );
+    const { message, signature } = await this.signStatement();
+    const { token } = await Fetcher.post<{ token: string }>(
+      this.url.endpoint('verify'),
+      {
+        body: JSON.stringify({
+          message,
+          signature,
+        }),
+      }
+    );
 
-        if (!this.verifyToken(token, await this.signer.getAddress())) {
-            throw new Error("Token verification failed");
-        }
-        this.store.setItem(StoreKeys.AUTH_TOKEN, token);
-        return token;
+    if (!this.verifyToken(token, await this.signer.getAddress())) {
+      throw new Error('Token verification failed');
     }
+    this.store.setItem(StoreKeys.AUTH_TOKEN, token);
+    return token;
+  }
 
-    private async signStatement() {
-        if (!this.signer.provider)
-            throw new Error("signer does not have a provider");
-        const date = new Date();
-        const expirationTime = new Date(date.getTime() + 300 * 1000); //message expires in 5min
+  private async signStatement() {
+    if (!this.signer.provider)
+      throw new Error('signer does not have a provider');
+    const date = new Date();
+    const expirationTime = new Date(date.getTime() + 300 * 1000); //message expires in 5min
 
-        const { nonce } = await Fetcher.get<{
-            nonce: string;
-        }>(this.url.endpoint("nonce"));
+    const { nonce } = await Fetcher.get<{
+      nonce: string;
+    }>(this.url.endpoint('nonce'));
 
-        const network = await this.signer.provider.getNetwork();
-        const message = new SiweMessage({
-            domain: this.domain,
-            address: await this.signer.getAddress(),
-            statement: this.signingStatement,
-            nonce,
-            uri: "https://" + this.domain,
-            version: "1",
-            chainId: +network.chainId.toString(),
-            expirationTime: expirationTime.toISOString(),
-        });
-        const preparedMessage = message.prepareMessage();
-        const signature = await this.signer.signMessage(preparedMessage);
-        return {
-            message: preparedMessage,
-            signature,
-        };
-    }
+    const network = await this.signer.provider.getNetwork();
+    const message = new SiweMessage({
+      domain: this.domain,
+      address: await this.signer.getAddress(),
+      statement: this.signingStatement,
+      nonce,
+      uri: 'https://' + this.domain,
+      version: '1',
+      chainId: +network.chainId.toString(),
+      expirationTime: expirationTime.toISOString(),
+    });
+    const preparedMessage = message.prepareMessage();
+    const signature = await this.signer.signMessage(preparedMessage);
+    return {
+      message: preparedMessage,
+      signature,
+    };
+  }
 }
 
 const parseJwt = (token: string) => {
-    try {
-        if (token.split(".").length < 3) return;
-        const jwt = token.split(".")[1];
-        if (!jwt) return;
-        //TODO: check this once
-        return JSON.parse(Buffer.from(jwt, "base64").toString("latin1"));
-    } catch {
-        return;
-    }
+  try {
+    if (token.split('.').length < 3) return;
+    const jwt = token.split('.')[1];
+    if (!jwt) return;
+    //TODO: check this once
+    return JSON.parse(Buffer.from(jwt, 'base64').toString('latin1'));
+  } catch {
+    return;
+  }
 };

--- a/packages/orderbook/src/lib/orderbook.ts
+++ b/packages/orderbook/src/lib/orderbook.ts
@@ -16,7 +16,7 @@ import { orderPairGenerator } from './orderpair';
 import { OrderbookErrors } from './errors';
 import { StoreKeys } from './store/store.interface';
 import { MemoryStorage } from './store/memoryStorage';
-import { API } from './api';
+import { MAINNET_ORDERBOOK_API } from './api';
 import { Url } from './url';
 import { Chain, SupportedContracts } from './asset';
 
@@ -39,7 +39,7 @@ export class Orderbook implements IOrderbook {
    *
    */
   constructor(orderbookConfig: OrderbookConfig) {
-    this.url = new Url('/', orderbookConfig.url ?? API);
+    this.url = new Url('/', orderbookConfig.url ?? MAINNET_ORDERBOOK_API);
     this.orderSocket = new OrdersSocket(this.url.socket());
 
     this.auth = new Siwe(this.url, orderbookConfig.signer, {
@@ -56,7 +56,7 @@ export class Orderbook implements IOrderbook {
 
   static async init(orderbookConfig: OrderbookConfig) {
     const auth = new Siwe(
-      new Url('/', orderbookConfig.url ?? API),
+      new Url('/', orderbookConfig.url ?? MAINNET_ORDERBOOK_API),
       orderbookConfig.signer,
       orderbookConfig.opts
     );


### PR DESCRIPTION
Adds two constants for mainnet and test apis and exports them 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new constants for `MAINNET_ORDERBOOK_API` and `TESTNET_ORDERBOOK_API`, enhancing access to specific order book APIs.
- **Bug Fixes**
	- Updated default API endpoint in the `Siwe` class to use `MAINNET_ORDERBOOK_API`, improving reliability.
- **Refactor**
	- Enhanced code readability through consistent formatting and structural adjustments, including quotation marks and indentation.
- **Chores**
	- Version updated from `0.1.9` to `0.1.10` for the package `@gardenfi/orderbook`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->