### PR TITLE
fix/starknet-approval issue

### DIFF
--- a/packages/core/src/lib/starknet/relay/starknetRelay.ts
+++ b/packages/core/src/lib/starknet/relay/starknetRelay.ts
@@ -37,7 +37,7 @@ const INITIATE_TYPE = {
   ],
 };
 
-const DEFAULT_NODE_URL = 'https://starknet-sepolia.public.blastapi.io/rpc/v0_7';
+const DEFAULT_NODE_URL = 'https://starknet-sepolia.public.blastapi.io/rpc/v0_8';
 
 export class StarknetRelay implements IStarknetHTLC {
   private url: Url;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default Starknet node URL to use the latest Sepolia public Blast API endpoint (v0_8).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->