### PR TITLE
feat: add timeout parameter to waitForTransactionReceipt in approve.ts

### DIFF
--- a/packages/utils/src/lib/approve.ts
+++ b/packages/utils/src/lib/approve.ts
@@ -37,7 +37,6 @@ export const checkAllowanceAndApprove = async (
           chain: walletClient.chain,
         },
       );
-      console.log('approval tx: ', res);
 
       const receipt = await waitForTransactionReceipt(walletClient, res);
       if (receipt.error) return Err(receipt.error);

--- a/packages/utils/src/lib/approve.ts
+++ b/packages/utils/src/lib/approve.ts
@@ -33,6 +33,7 @@ export const checkAllowanceAndApprove = async (
       );
       const receipt = await waitForTransactionReceipt(walletClient, {
         hash: res,
+        timeout: 60000,
       });
       if (receipt.status !== 'success') return Err('Failed to approve');
 

--- a/packages/utils/src/lib/approve.ts
+++ b/packages/utils/src/lib/approve.ts
@@ -31,10 +31,13 @@ export const checkAllowanceAndApprove = async (
           chain: walletClient.chain,
         },
       );
+      console.log('approval tx: ', res);
+
       const receipt = await waitForTransactionReceipt(walletClient, {
         hash: res,
         timeout: 60000,
       });
+      console.log('receipt: ', receipt);
       if (receipt.status !== 'success') return Err('Failed to approve');
 
       return Ok(res);

--- a/packages/utils/src/lib/approve.ts
+++ b/packages/utils/src/lib/approve.ts
@@ -4,7 +4,6 @@ import {
   getContract,
   maxUint256,
   TransactionReceipt,
-  TransactionReceiptNotFoundError,
   WalletClient,
 } from 'viem';
 import { with0x } from './utils';
@@ -68,7 +67,8 @@ export const waitForTransactionReceipt = async (
         return Ok(receipt);
       }
     } catch (err: unknown) {
-      if (err instanceof TransactionReceiptNotFoundError) {
+      console.log('txReceipt err: ', err);
+      if ((err as Error).message.includes('Transaction receipt with hash')) {
         // ignore and continue polling
       } else {
         // for other errors, propagate immediately

--- a/packages/utils/src/lib/approve.ts
+++ b/packages/utils/src/lib/approve.ts
@@ -67,11 +67,11 @@ export const waitForTransactionReceipt = async (
         return Ok(receipt);
       }
     } catch (err: unknown) {
-      console.log('txReceipt err: ', err);
-      if ((err as Error).message.includes('Transaction receipt with hash')) {
-        // ignore and continue polling
-      } else {
-        // for other errors, propagate immediately
+      if (
+        !(err as Error).message.includes(
+          `Transaction receipt with hash "${hash}" could not be found.`,
+        )
+      ) {
         return Err((err as Error).message);
       }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated transaction approval process to enforce a maximum wait time of 60 seconds for completion.
  - Improved transaction receipt polling with enhanced error handling and status verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->