### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
 
@@ -155,7 +155,7 @@ jobs:
           echo "PACKAGE_NAMES=$PACKAGE_NAMES" >> $GITHUB_ENV
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
 
@@ -199,7 +199,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
 


### PR DESCRIPTION
Bumps setup-node to v4 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/actions/setup-node/releases/tag/v4.0.0